### PR TITLE
Add ability to report 0 coverage issues in-line

### DIFF
--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -25,7 +25,7 @@ module Danger
     # @return  [void]
     #
     def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, fail_0_coverage: false)
-      return warn('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
+      return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
 

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -35,7 +35,7 @@ module Danger
         report.each_line do |line|
           next unless line.strip.start_with?("loc:")
 
-          _, filename, from_line, to_line = *line.match(/loc:\s([^:]*):(\d+):(\d+)/)
+          _, filename, from_line, to_line = *line.match(/loc:\s([^:]+):(\d+):(\d+)/)
           warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
         end
 

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -24,7 +24,7 @@ module Danger
     # If there are reports then it shows the report as a warning in danger.
     # @return  [void]
     #
-    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, fail_0_coverage: false)
+    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, fail_on_missing_coverage: false)
       return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
@@ -39,7 +39,7 @@ module Danger
           warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
         end
 
-        fail(report, sticky: sticky) if fail_0_coverage
+        fail(report, sticky: sticky) if fail_on_missing_coverage
       else
         message(report, sticky: sticky)
       end

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -30,16 +30,16 @@ module Danger
       report = File.open(undercover_path).read.force_encoding('UTF-8')
 
       if report.match(/some methods have no test coverage/)
-        warn(report, sticky: sticky)
+        return warn(report, sticky: sticky) unless in_line
 
-        if in_line
-          report.each_line.with_index do |line, i|
-            next unless line.strip.start_with?("loc:")
+        report.each_line.with_index do |line, i|
+          next unless line.strip.start_with?("loc:")
 
-            _, filename, from_line, to_line = line.match(/loc:\s([^:]*):(\d+):(\d+)/)
-            fail("🚨 👮‍♂️ Coverage reported 0 hits", file: filename, line: from_line.to_i, sticky: sticky)
-          end
+          _, filename, from_line, to_line = line.match(/loc:\s([^:]*):(\d+):(\d+)/)
+          warn("🚨 👮‍♂️ Coverage reported 0 hits", file: filename, line: from_line.to_i, sticky: sticky)
         end
+
+        fail(report, sticky: sticky)
       else
         message(report, sticky: sticky)
       end

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -24,7 +24,7 @@ module Danger
     # If there are reports then it shows the report as a warning in danger.
     # @return  [void]
     #
-    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false)
+    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, fail_0_coverage: false)
       return warn('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
@@ -32,14 +32,14 @@ module Danger
       if report.match(/some methods have no test coverage/)
         return warn(report, sticky: sticky) unless in_line
 
-        report.each_line.with_index do |line, i|
+        report.each_line do |line|
           next unless line.strip.start_with?("loc:")
 
           _, filename, from_line, to_line = *line.match(/loc:\s([^:]*):(\d+):(\d+)/)
           warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
         end
 
-        fail(report, sticky: sticky)
+        fail(report, sticky: sticky) if fail_0_coverage
       else
         message(report, sticky: sticky)
       end

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -24,13 +24,22 @@ module Danger
     # If there are reports then it shows the report as a warning in danger.
     # @return  [void]
     #
-    def report(undercover_path = DEFAULT_PATH, sticky: true)
-      return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
+    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false)
+      return warn('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
 
       if report.match(/some methods have no test coverage/)
         warn(report, sticky: sticky)
+
+        if in_line
+          report.each_line.with_index do |line, i|
+            next unless line.strip.start_with?("loc:")
+
+            _, filename, from_line, to_line = line.match(/loc:\s([^:]*):(\d+):(\d+)/)
+            fail("🚨 👮‍♂️ Coverage reported 0 hits", file: filename, line: from_line.to_i, sticky: sticky)
+          end
+        end
       else
         message(report, sticky: sticky)
       end

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -36,7 +36,7 @@ module Danger
           next unless line.strip.start_with?("loc:")
 
           _, filename, from_line, to_line = line.match(/loc:\s([^:]*):(\d+):(\d+)/)
-          warn("🚨 👮‍♂️ Coverage reported 0 hits", file: filename, line: from_line.to_i, sticky: sticky)
+          warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
         end
 
         fail(report, sticky: sticky)

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -35,7 +35,7 @@ module Danger
         report.each_line.with_index do |line, i|
           next unless line.strip.start_with?("loc:")
 
-          _, filename, from_line, to_line = line.match(/loc:\s([^:]*):(\d+):(\d+)/)
+          _, filename, from_line, to_line = *line.match(/loc:\s([^:]*):(\d+):(\d+)/)
           warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
         end
 

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -45,10 +45,10 @@ module Danger
           expect(@dangerfile.status_report[:warnings].count).to eq(3)
         end
 
-        context "when fail_0_coverage option is true" do
+        context "when fail_on_missing_coverage option is true" do
           it 'reports 0 coverage as a failure' do
             report_path = 'spec/fixtures/undercover_failed.txt'
-            @undercover.report(report_path, in_line: true, fail_0_coverage: true)
+            @undercover.report(report_path, in_line: true, fail_on_missing_coverage: true)
 
             report = File.open(report_path).read
 

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -14,10 +14,10 @@ module Danger
         @undercover = @dangerfile.undercover
       end
 
-      it 'shows warnings if file is not found' do
+      it 'fails if file is not found' do
         @undercover.report('spec/fixtures/missing_file.txt')
 
-        expect(@dangerfile.status_report[:warnings]).to eq(['Undercover: coverage report cannot be found.'])
+        expect(@dangerfile.status_report[: errors]).to eq(['Undercover: coverage report cannot be found.'])
       end
 
       it 'shows success message if nothing to report' do

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -37,14 +37,23 @@ module Danger
       end
 
       context "when in_line option is true" do
-        it 'shows in-line failures for each reported issue' do
+        it 'shows in-line warnings for each reported issue' do
           report_path = 'spec/fixtures/undercover_failed.txt'
           @undercover.report(report_path, in_line: true)
 
-          report = File.open(report_path).read
-
-          expect(@dangerfile.status_report[:errors]).to eq([report])
+          expect(@dangerfile.status_report[:errors]).to be_empty
           expect(@dangerfile.status_report[:warnings].count).to eq(3)
+        end
+
+        context "when fail_0_coverage option is true" do
+          it 'reports 0 coverage as a failure' do
+            report_path = 'spec/fixtures/undercover_failed.txt'
+            @undercover.report(report_path, in_line: true, fail_0_coverage: true)
+
+            report = File.open(report_path).read
+
+            expect(@dangerfile.status_report[:errors]).to eq([report])
+          end
         end
       end
     end

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -14,10 +14,10 @@ module Danger
         @undercover = @dangerfile.undercover
       end
 
-      it 'fails if file is not found' do
+      it 'shows warnings if file is not found' do
         @undercover.report('spec/fixtures/missing_file.txt')
 
-        expect(@dangerfile.status_report[:errors]).to eq(['Undercover: coverage report cannot be found.'])
+        expect(@dangerfile.status_report[:warnings]).to eq(['Undercover: coverage report cannot be found.'])
       end
 
       it 'shows success message if nothing to report' do
@@ -34,6 +34,15 @@ module Danger
         report = File.open(report_path).read
 
         expect(@dangerfile.status_report[:warnings]).to eq([report])
+      end
+
+      context "when in_line option is true" do
+        it 'shows in-line failures for each reported issue' do
+          report_path = 'spec/fixtures/undercover_failed.txt'
+          @undercover.report(report_path, in_line: true)
+
+          expect(@dangerfile.status_report[:errors].count).to eq(3)
+        end
       end
     end
   end

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -41,7 +41,10 @@ module Danger
           report_path = 'spec/fixtures/undercover_failed.txt'
           @undercover.report(report_path, in_line: true)
 
-          expect(@dangerfile.status_report[:errors].count).to eq(3)
+          report = File.open(report_path).read
+
+          expect(@dangerfile.status_report[:errors]).to eq([report])
+          expect(@dangerfile.status_report[:warnings].count).to eq(3)
         end
       end
     end


### PR DESCRIPTION
As part of our quality check we want to be able to:

Be able to fail checks instead of only reporting warning
Be able to comment in-line on a Pull Request for each block or line of new code that is missing test coverage
In order to achieve that we have forked the main repo of the danger-undercover plugin so we can play around and eventually ask the main repo guys if they would like to have this extra functionality or not.

About the change, two new params are now accepted by the plugin.

in_line will regex the undercover report and add in-line comments for each block or line of code with 0 test coverage
fail_0_coverage when true will generate a failure for the danger check so that our quality gate will block code from going in