### PR TITLE
Add ability to limit reported results to GitHub

### DIFF
--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -45,10 +45,9 @@ module Danger
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
 
-      # Returns and add a message if is all good.
+      # Returns and adds a message if all is good.
       return message(cut_report(report), sticky: sticky) unless report.match(/some methods have no test coverage/)
 
-      # Returns the content of the report unless `in_line` option is true
       return report_with_type(report_danger, cut_report(report), sticky) unless in_line
 
       reported_inline_comments = 0

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -36,7 +36,7 @@ module Danger
     #   - *max_inline_comments* determine the maximum number of reported messages.
     #     Used to avoid Github API abuse mechanism.
     #     When limit is reached, a custom message is added to inform the user.
-    #     Defaults to 10.
+    #     Defaults to MAX_INLINE_COMMENTS.
     #
     # @return  [void]
     #

--- a/lib/undercover/plugin.rb
+++ b/lib/undercover/plugin.rb
@@ -17,32 +17,60 @@ module Danger
   class DangerUndercover < Plugin
     VALID_FILE_FORMAT = '.txt'
     DEFAULT_PATH = 'coverage/undercover.txt'
+    MAX_INLINE_COMMENTS = 30
+    MAX_CHARACTERS_PER_MESSAGE = 60_000
 
-    # Checks the file validity and warns if no file is found
-    # if a valid file is found then if there are no changes,
-    # shows the report as a message in Danger.
-    # If there are reports then it shows the report as a warning in danger.
+    # Checks the file validity and fails if no file is found.
+    # If a valid file is found, the content of it will be parsed according to options
+    # and reports will be sent to danger.
+    #
+    # Options
+    #   - *undercover_path* the path to the undercover.txt file.
+    #     Defaults to `coverage/undercover.txt`.
+    #   - *sticky* from (danger)[https://danger.systems/reference.html].
+    #     Defaults to `true`.
+    #   - *in_line* when `true` will report each line or block missing coverage as an in-line comment.
+    #     Defaults to `false`.
+    #   - *report_danger* when `true` will report a failure to danger when new code is at 0 test coverage.
+    #     Defaults to `false`, so it generates warnings instead.
+    #   - *max_inline_comments* determine the maximum number of reported messages.
+    #     Used to avoid Github API abuse mechanism.
+    #     When limit is reached, a custom message is added to inform the user.
+    #     Defaults to 10.
+    #
     # @return  [void]
     #
-    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, fail_on_missing_coverage: false)
+    def report(undercover_path = DEFAULT_PATH, sticky: true, in_line: false, report_danger: false, max_inline_comments: MAX_INLINE_COMMENTS)
       return fail('Undercover: coverage report cannot be found.') unless valid_file? undercover_path
 
       report = File.open(undercover_path).read.force_encoding('UTF-8')
 
-      if report.match(/some methods have no test coverage/)
-        return warn(report, sticky: sticky) unless in_line
+      # Returns and add a message if is all good.
+      return message(cut_report(report), sticky: sticky) unless report.match(/some methods have no test coverage/)
 
-        report.each_line do |line|
-          next unless line.strip.start_with?("loc:")
+      # Returns the content of the report unless `in_line` option is true
+      return report_with_type(report_danger, cut_report(report), sticky) unless in_line
 
-          _, filename, from_line, to_line = *line.match(/loc:\s([^:]+):(\d+):(\d+)/)
-          warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
+      reported_inline_comments = 0
+
+      report.each_line do |line|
+        next unless line.strip.start_with?("loc:")
+
+        reported_inline_comments += 1
+        _, filename, from_line, to_line = *line.match(/loc:\s([^:]+):(\d+):(\d+)/)
+        warn("Coverage reported 0 hits #{line}", file: filename, line: from_line.to_i, sticky: sticky)
+
+        if reported_inline_comments >= max_inline_comments
+          summary_message = "The maximum number of in-line comments for 0 test" \
+                            " coverage has been reached.\n" \
+                            "Fix the reported issues to see more."
+
+          break
         end
-
-        fail(report, sticky: sticky) if fail_on_missing_coverage
-      else
-        message(report, sticky: sticky)
       end
+
+      summary_message ||= "#{reported_inline_comments} reported issues with test coverage."
+      report_with_type(report_danger, summary_message, sticky)
     end
 
     private
@@ -52,6 +80,29 @@ module Danger
     #
     def valid_file?(undercover_path)
       File.exist?(undercover_path) && (File.extname(undercover_path) == VALID_FILE_FORMAT)
+    end
+
+    # Cuts the undercover report to MAX_CHARACTERS_PER_MESSAGE of characters,
+    # to stay below the `65_536` characters. Also adds elipses to make it clear
+    # to viewers that the content was truncated.
+    # Check https://github.com/danger/danger/issues/756
+    # @return [Void]
+    #
+    def cut_report(report)
+      return report if report.size <= MAX_CHARACTERS_PER_MESSAGE
+
+      report[0..MAX_CHARACTERS_PER_MESSAGE] + " ... [Message Truncated]"
+    end
+
+    # Report message as `fail` or `warn` depending on `report_danger` value
+    # @return [Void]
+    #
+    def report_with_type(report_danger, message, sticky)
+      if report_danger
+        fail(message, sticky: sticky)
+      else
+        warn(message, sticky: sticky)
+      end
     end
   end
 end

--- a/spec/fixtures/undercover_failed_big.txt
+++ b/spec/fixtures/undercover_failed_big.txt
@@ -1,0 +1,1904 @@
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s
+undercover: 👮‍♂️ some methods have no test coverage! Please add specs for methods listed below
+🚨 1) node `index3` type: instance method,
+      loc: app/controllers/v2/provinces_controller.rb:9:11, coverage: 0.0%
+ 9:     def index3 hits: n/a
+10:       render json: V2::ProvinceSerializer.new(provinces) hits: 0
+11:     end hits: n/a
+🚨 2) node `index2` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:9:11, coverage: 0.0%
+ 9:     def index2 hits: n/a
+10:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+11:     end hits: n/a
+🚨 3) node `index3` type: instance method,
+      loc: app/controllers/v2/sub_districts_controller.rb:13:15, coverage: 0.0%
+13:     def index3 hits: n/a
+14:       render json: V2::SubDistrictSerializer.new(sub_districts) hits: 0
+15:     end hits: n/a
+Undercover finished in 0.9006s

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -36,7 +36,7 @@ module Danger
         expect(@dangerfile.status_report[:warnings]).to eq([report])
       end
 
-      context 'when report size exceed 60k' do
+      context 'when report size exceeds 60k' do
         it 'reports a warning with a trimmered message' do
           report_path = 'spec/fixtures/undercover_failed_big.txt'
           @undercover.report(report_path)

--- a/spec/undercover_spec.rb
+++ b/spec/undercover_spec.rb
@@ -17,7 +17,7 @@ module Danger
       it 'fails if file is not found' do
         @undercover.report('spec/fixtures/missing_file.txt')
 
-        expect(@dangerfile.status_report[: errors]).to eq(['Undercover: coverage report cannot be found.'])
+        expect(@dangerfile.status_report[:errors]).to eq(['Undercover: coverage report cannot be found.'])
       end
 
       it 'shows success message if nothing to report' do
@@ -36,23 +36,43 @@ module Danger
         expect(@dangerfile.status_report[:warnings]).to eq([report])
       end
 
-      context "when in_line option is true" do
+      context 'when report size exceed 60k' do
+        it 'reports a warning with a trimmered message' do
+          report_path = 'spec/fixtures/undercover_failed_big.txt'
+          @undercover.report(report_path)
+
+          report = File.open(report_path).read
+          warning = @dangerfile.status_report[:warnings].first
+
+          expect(warning).to end_with('[Message Truncated]')
+        end
+      end
+
+      context "when the in_line option is true" do
         it 'shows in-line warnings for each reported issue' do
           report_path = 'spec/fixtures/undercover_failed.txt'
           @undercover.report(report_path, in_line: true)
 
-          expect(@dangerfile.status_report[:errors]).to be_empty
-          expect(@dangerfile.status_report[:warnings].count).to eq(3)
+          expect(@dangerfile.status_report[:warnings].count).to eq(4)
         end
 
-        context "when fail_on_missing_coverage option is true" do
+        context 'when the maximum number of in-line comments is reached' do
+          it 'reports the maximum allowed of in-line comments and ' do
+            report_path = 'spec/fixtures/undercover_failed.txt'
+            @undercover.report(report_path, in_line: true, max_inline_comments: 1)
+
+            expect(@dangerfile.status_report[:warnings].count).to eq(2)
+          end
+        end
+
+        context "when report_danger option is true" do
           it 'reports 0 coverage as a failure' do
             report_path = 'spec/fixtures/undercover_failed.txt'
-            @undercover.report(report_path, in_line: true, fail_on_missing_coverage: true)
+            @undercover.report(report_path, in_line: true, report_danger: true)
 
             report = File.open(report_path).read
 
-            expect(@dangerfile.status_report[:errors]).to eq([report])
+            expect(@dangerfile.status_report[:errors].count).to eq(1)
           end
         end
       end


### PR DESCRIPTION
When testing the danger-undercover behaviour on Big Pull request we stumped upon some issues all in regards to the size of the reported messages.

The first encountered issue had to deal with the fact that Github API have an abuse mechanism that is triggered by too many in-line messages, hence failing our danger run.
To fix this, we introduced a MAX_INLINE_COMMENTS value which will limit comments to 30, and is configurable.

The second issue had to deal with the size of the single `report` message when the `in-line` option is `false`.
For that, we are trimmering the message to 60k of characters. Given that `danger` does decorate messages further, we have left a good gap to not encounter the size limit reached error. More info about why it is, can be found [here](https://github.com/danger/danger/issues/756)